### PR TITLE
Support running ovn-central as clustered db for ovn-fake-multinode de…

### DIFF
--- a/rally_ovs/plugins/ovs/context/ovnnbctl_daemon.py
+++ b/rally_ovs/plugins/ovs/context/ovnnbctl_daemon.py
@@ -28,6 +28,11 @@ class OvnNbctlDaemonContext(ovnclients.OvnClientMixin, context.Context):
         "$schema": consts.JSON_SCHEMA,
         "properties": {
             "daemon_mode": {"type": "boolean"},
+            "remote": {"type": "string"},
+            "prot": {"type": "string"},
+            "privkey": {"type": "string"},
+            "cert": {"type": "string"},
+            "cacert": {"type": "string"},
         },
         "additionalProperties": True
     }
@@ -41,7 +46,7 @@ class OvnNbctlDaemonContext(ovnclients.OvnClientMixin, context.Context):
         super(OvnNbctlDaemonContext, self).setup()
 
         if self.config["daemon_mode"]:
-            self.context["daemon_socket"] = self._restart_daemon()
+            self.context["daemon_socket"] = self._restart_daemon(self.config)
         else:
             self._stop_daemon()
 

--- a/rally_ovs/plugins/ovs/ovnclients.py
+++ b/rally_ovs/plugins/ovs/ovnclients.py
@@ -31,9 +31,9 @@ class OvnClientMixin(ovsclients.ClientsMixin, RandomNameGeneratorMixin):
         ovn_nbctl.set_daemon_socket(self.context.get("daemon_socket", None))
         return ovn_nbctl
 
-    def _start_daemon(self):
+    def _start_daemon(self, nbctld_config):
         ovn_nbctl = self._get_ovn_controller(self.install_method)
-        ret = ovn_nbctl.start_daemon()
+        ret = ovn_nbctl.start_daemon(nbctld_config)
         ovn_nbctl.close()
         return ret
 
@@ -42,9 +42,9 @@ class OvnClientMixin(ovsclients.ClientsMixin, RandomNameGeneratorMixin):
         ovn_nbctl.stop_daemon()
         ovn_nbctl.close()
 
-    def _restart_daemon(self):
+    def _restart_daemon(self, nbctld_config):
         self._stop_daemon()
-        return self._start_daemon()
+        return self._start_daemon(nbctld_config)
 
     def _get_gw_ip(self, network_cidr, offset=1):
         # Use the last IP (+ offset) in the CIDR as gateway IP.

--- a/samples/tasks/scenarios/ovn-network/osh_workload_incremental.json
+++ b/samples/tasks/scenarios/ovn-network/osh_workload_incremental.json
@@ -4,6 +4,8 @@
 {% set gw_router = gw_router or False %}
 {% set gw_batch_ops = gw_batch_ops or False %}
 {% set ovn_monitor_all = ovn_monitor_all or false %}
+{% set ovn_cluster_db = ovn_cluster_db or false %}
+{% set ovn_central_ip = ovn_central_ip or "192.16.0.1" %}
 {% set cluster_cmd_path = cluster_cmd_path or "/root/ovn-fake-testing/ovn-fake-multinode" %}
 {% set node_batch_size = node_batch_size or 1 %}
 {% set sla = sla or 30 %}
@@ -78,7 +80,8 @@
                     "name": "OvnFakeMultinode.del_central_node",
                     "args": {
                         "fake_multinode_args": {
-                            "cluster_cmd_path": {{cluster_cmd_path}}
+                            "cluster_cmd_path": {{cluster_cmd_path}},
+                            "ovn_cluster_db": {{ovn_cluster_db}}
                         }
                     },
                     "runner": {
@@ -140,7 +143,8 @@
                             "node_net_len": "16",
                             "node_ip": "192.16.0.1",
                             "cluster_cmd_path": {{cluster_cmd_path}},
-                            "ovn_monitor_all": {{ovn_monitor_all}}
+                            "ovn_monitor_all": {{ovn_monitor_all}},
+                            "ovn_cluster_db": {{ovn_cluster_db}}
                         }
                     },
                     "runner": {
@@ -166,9 +170,10 @@
                             "node_net": "192.16.0.0",
                             "node_net_len": "16",
                             "node_prefix": "ovn-farm-node-",
-                            "central_ip": "192.16.0.1",
+                            "central_ip": {{ovn_central_ip}},
                             "cluster_cmd_path": {{cluster_cmd_path}},
                             "ovn_monitor_all": {{ovn_monitor_all}},
+                            "ovn_cluster_db": {{ovn_cluster_db}},
                             "max_timeout_s": 10,
                             "batch_size": {{node_batch_size}}
                         },
@@ -212,7 +217,12 @@
                             }
                         },
                         "ovn-nbctld" : {
-                            "daemon_mode": True
+                            "daemon_mode": True,
+                            "remote": {{ovn_central_ip}},
+                            "prot": "ssl",
+                            "privkey": "/opt/ovn/ovn-privkey.pem",
+                            "cert": "/opt/ovn/ovn-cert.pem",
+                            "cacert": "/opt/ovn/pki/switchca/cacert.pem"
                         }
                     }
                 }
@@ -252,7 +262,12 @@
                        },
                        "ovn_nb": {},
                        "ovn-nbctld" : {
-                            "daemon_mode": True
+                            "daemon_mode": True,
+                            "remote": {{ovn_central_ip}},
+                            "prot": "ssl",
+                            "privkey": "/opt/ovn/ovn-privkey.pem",
+                            "cert": "/opt/ovn/ovn-cert.pem",
+                            "cacert": "/opt/ovn/pki/switchca/cacert.pem"
                        }
                     }
                 }


### PR DESCRIPTION
…ployments.

This patch also does 2 other things
  - Starts nbctl daemon with --db option if the remotes
    are set in the nbctl daemon context and if remotes > 1.
    i.e --db=ssl:IP1:6641,ssl:IP2:6641,ssl:IP3:6641 for example.

  - Whenever ovn-sbctl is invoked, it is invoked with --no-leader-only
    flag. If the Dbs are deployed as a raft cluster we want ovn-sbctl
    to not block, if the node on which it is run is not running leader.
    If the DBs are standalone, then this flag will be ignored by ovn-sbctl.

Signed-off-by: Numan Siddique <nusiddiq@redhat.com>